### PR TITLE
Adding a simple usePolling configuration variable to a ignoreWatcher …

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -151,7 +151,8 @@ exports.start = function(config) {
             nodePath.join(cwd, '.browser-refresh-ignore'),
             nodePath.join(cwd, '.gitignore')
         ],
-        defaultIgnorePatterns: DEFAULT_IGNORES
+        defaultIgnorePatterns: DEFAULT_IGNORES,
+        usePolling: config.usePolling || false
     });
 
     watcher


### PR DESCRIPTION
…constructor.

Enable polling by adding "usePolling": true to a .browser_refresh configuration file, otherwise it's false by default.

This fixes issue #22