### PR TITLE
Fixes: Add option to silence all output with an environment variable

### DIFF
--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -21,7 +21,7 @@ Logger.prototype = {
             message = message[color];
         }
 
-        console.log(message);
+        if (!process.env.BROWSER_REFRESH_SILENT) { console.log(message) };
     },
     status: function(message) {
         this._log('status', message);


### PR DESCRIPTION
Hey,

I have a partial solution to #39. You can make the output silent by setting `BROWSER_REFRESH_SILENT`.

Thanks.