### PR TITLE
Upgrade browserify to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "browser-request": "^0.3.3",
-    "browserify": "^9.0.3",
+    "browserify": "^14.4.0",
     "colors": "^0.6.2",
     "express": "^3.5.1",
     "ignoring-watcher": "^1.0.5",


### PR DESCRIPTION
to pick up vulnerability fix on `shell-quote@0.0.1`, which is fixed since [browserify@12.0.0](https://github.com/substack/node-browserify/commit/c77bf33e67781096368b7e2516d052cf69d2d2cf).
See https://nodesecurity.io/advisories/117 for details on shell-quote.
